### PR TITLE
Check backend integration with Calendly and Stripe

### DIFF
--- a/fix-404/app/consultation/page.tsx
+++ b/fix-404/app/consultation/page.tsx
@@ -27,7 +27,7 @@ export default function ConsultationPage() {
             {/* Calendly Widget */}
             <div className="w-full">
               <iframe
-                src="https://calendly.com/services-tidymate/30min?embed_domain=${typeof window !== 'undefined' ? window.location.hostname : ''}&embed_type=Inline&hide_event_type_details=1&hide_gdpr_banner=1&primary_color=000000&text_color=4d4d4d"
+                src={`https://calendly.com/services-tidymate/30min?embed_domain=${typeof window !== 'undefined' ? window.location.hostname : ''}&embed_type=Inline&hide_event_type_details=1&hide_gdpr_banner=1&primary_color=000000&text_color=4d4d4d`}
                 width="100%"
                 height="700"
                 frameBorder="0"


### PR DESCRIPTION
Fix Calendly iframe `src` to correctly interpolate the hostname by using a template literal.

---
<a href="https://cursor.com/background-agent?bcId=bc-aee41afa-5424-4b42-a6d2-541b3eb5a349">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aee41afa-5424-4b42-a6d2-541b3eb5a349">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

